### PR TITLE
Allow project loading

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "Ecdar-GUI-Web"]
 	path = Ecdar-GUI-Web
-	url = git@github.com:ECDAR-AAU-SW-P5/Ecdar-GUI-Web.git
+	url = https://github.com/ECDAR-AAU-SW-P5/Ecdar-GUI-Web.git

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -17,7 +17,7 @@ tauri-build = { version = "1.4.0", features = [ ] }
 [dependencies]
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-tauri = { version = "1.4.0", features = [ "dialog-save", "dialog-open", "fs-read-dir", "fs-create-dir", "fs-remove-dir", "fs-read-file", "fs-write-file", "fs-remove-file", "path-all" ] }
+tauri = { version = "1.4.0", features = [ "dialog-confirm", "dialog-save", "dialog-open", "fs-read-dir", "fs-create-dir", "fs-remove-dir", "fs-read-file", "fs-write-file", "fs-remove-file", "path-all" ] }
 tauri-plugin-persisted-scope = "0.1.3"
 tonic = "0.10.2"
 rand = "0.8.5"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -17,7 +17,8 @@ tauri-build = { version = "1.4.0", features = [ ] }
 [dependencies]
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-tauri = { version = "1.4.0", features = [ "dialog-confirm", "dialog-open", "fs-create-dir", "fs-write-file", "fs-read-dir", "fs-exists", "fs-read-file"] }
+tauri = { version = "1.4.0", features = [ "dialog-save", "dialog-open", "fs-read-dir", "fs-create-dir", "fs-remove-dir", "fs-read-file", "fs-write-file", "fs-remove-file", "path-all" ] }
+tauri-plugin-persisted-scope = "0.1.3"
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem and the built-in dev server is disabled.

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -5,6 +5,7 @@ use tauri::Manager;
 
 fn main() {
   tauri::Builder::default()
+    .plugin(tauri_plugin_persisted_scope::init())
     .setup(|app| {
         #[cfg(debug_assertions)]
         {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -14,7 +14,7 @@
     "allowlist": {
       "dialog": {
         "ask": false,
-        "confirm": false,
+        "confirm": true,
         "message": false,
         "open": true,
         "save": true 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -12,12 +12,12 @@
   },
   "tauri": {
     "allowlist": {
-    "dialog": {
+      "dialog": {
         "ask": false,
-        "confirm": true,
+        "confirm": false,
         "message": false,
         "open": true,
-        "save": false 
+        "save": true 
       },
       "fs": {
         "readFile": true,
@@ -25,10 +25,13 @@
         "readDir": true,
         "copyFile": false,
         "createDir": true,
-        "removeDir": false,
-        "removeFile": false,
+        "removeDir": true,
+        "removeFile": true,
         "renameFile": false,
-        "exists": true
+        "exists": false
+      },
+      "path": {
+        "all": true
       }
     },
     "bundle": {


### PR DESCRIPTION
The new project loader that is about to be merged in https://github.com/ECDAR-AAU-SW-P5/Ecdar-GUI-Web/pull/99 has some slightly different requirements for file access.

This PR ensures it can access everything it needs, and only what it needs.